### PR TITLE
Disable password authentication if SNOWFLAKE_AUTHENTICATOR is set

### DIFF
--- a/schemachange/cli.py
+++ b/schemachange/cli.py
@@ -271,7 +271,7 @@ class SnowflakeSchemachangeSession:
         warnings.warn(_warn_password, DeprecationWarning)
         snowflake_password = os.getenv("SNOWSQL_PWD")
 
-    if snowflake_password:
+    if snowflake_password and not os.getenv("SNOWFLAKE_AUTHENTICATOR"):
       if self.verbose:
         print(_log_auth_type %  'password' )
       self.conArgs['password'] = snowflake_password


### PR DESCRIPTION
When using `authenticator=externalbrowser`, the `snowflake.connector.connect()` method requires a value for the password parameter.  However, if we provide an value for the password in the env variable SNOWFLAKE_PASSWORD, then `cli.py` forces password authentication. This means it is currently impossible to use externalbrowser authenitcation.

I would argue that if we set a value for SNOWFLAKE_AUTHENTICATOR, then password authentication is explicitly unwanted. This patch reflects this behavior.